### PR TITLE
Update Validator.java

### DIFF
--- a/saripaar/src/main/java/com/mobsandgeeks/saripaar/Validator.java
+++ b/saripaar/src/main/java/com/mobsandgeeks/saripaar/Validator.java
@@ -239,7 +239,7 @@ public class Validator {
 
         // Find adapter's data type
         Method getDataMethod = Reflector.findGetDataMethod(viewDataAdapter.getClass());
-        Class<?> adapterDataType = getDataMethod.getReturnType();
+        Class<?> adapterDataType = (getDataMethod != null) ? getDataMethod.getReturnType() : "";
 
         dataTypeAdapterMap.put(adapterDataType, viewDataAdapter);
     }


### PR DESCRIPTION
Handling NPE for getReturnType() method. Shown as below -
Caused by java.lang.NullPointerException
Attempt to invoke virtual method 'java.lang.Class java.lang.reflect.Method.getReturnType()' on a null object reference
com.mobsandgeeks.saripaar.Validator.registerAdapter